### PR TITLE
added skip array feature

### DIFF
--- a/src/bin/from_stdin.rs
+++ b/src/bin/from_stdin.rs
@@ -42,7 +42,7 @@ fn main() {
 
 fn process_line(value: &Value) -> Result<()> {
     let mut flat_value: Value = json!({});
-    flatten(value, &mut flat_value, None, true)?;
+    flatten(value, &mut flat_value, None, true, false)?;
     io::stdout().write_all(serde_json::to_string(&flat_value)?.as_bytes())?;
     io::stdout().write_all(b"\n")?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,18 @@ foreign_links {
     }
 }
 
-pub fn flatten(nested_value: &Value, flat_value: &mut Value, parent_key: Option<String>, infer_type: bool) -> Result<()> {
+pub fn flatten(nested_value: &Value, flat_value: &mut Value, parent_key: Option<String>, infer_type: bool, skip_arrays: bool) -> Result<()> {
     // if object
     if let Some(nested_dict) = nested_value.as_object() {
-        flatten_object(flat_value, &parent_key, nested_dict, infer_type)?;
+        flatten_object(flat_value, &parent_key, nested_dict, infer_type, skip_arrays)?;
     } else if let Some(v_array) = nested_value.as_array() {
         let new_k = parent_key.unwrap_or_else(||String::from(""));
-        flatten_array(flat_value, &new_k, v_array, infer_type)?;
+        if !skip_arrays {
+            flatten_array(flat_value, &new_k, v_array, infer_type)?;
+        }
+        else {
+            error!("Cannot flatten json array with skip_arrays = true")
+        }
     } else {
         error!("Expected object, found something else: {:?}", nested_value)
     }
@@ -28,7 +33,7 @@ pub fn flatten(nested_value: &Value, flat_value: &mut Value, parent_key: Option<
 }
 
 
-fn flatten_object(flat_value: &mut Value, parent_key: &Option<String>, nested_dict: &Map<String, Value>, infer_type: bool) -> Result<()> {
+fn flatten_object(flat_value: &mut Value, parent_key: &Option<String>, nested_dict: &Map<String, Value>, infer_type: bool, skip_arrays: bool) -> Result<()> {
     for (k, v) in nested_dict.iter() {
         let new_k = match parent_key {
             Some(ref key) => format!("{}.{}", key, k),
@@ -36,19 +41,23 @@ fn flatten_object(flat_value: &mut Value, parent_key: &Option<String>, nested_di
         };
         // if nested value is object recurse with parent_key
         if let Some(obj) = v.as_object() {
-            flatten_object(flat_value, &Some(new_k), obj, infer_type)?;
+            flatten_object(flat_value, &Some(new_k), obj, infer_type, skip_arrays)?;
             // if array
         } else if let Some(v_array) = v.as_array() {
             // if array is not empty
-            if !v_array.is_empty() {
-                // traverse array
-                flatten_array(flat_value, &new_k, v_array, infer_type)?;
-                // if array is empty insert empty array into flat_value
-            } else if let Some(value) = flat_value.as_object_mut() {
-                let empty: Vec<Value> = vec!();
-                value.insert(k.to_string(), json!(empty));
-            }
+            if !skip_arrays{
+                if !v_array.is_empty() {
+                    // traverse array
+                    flatten_array(flat_value, &new_k, v_array, infer_type)?;
+                    // if array is empty insert empty array into flat_value
+                } else if let Some(value) = flat_value.as_object_mut() {
+                    let empty: Vec<Value> = vec!();
+                    value.insert(k.to_string(), json!(empty));
+                }
             // if no object or array insert value into the flat_value we're building
+            } else if let Some(value) = flat_value.as_object_mut() {
+                infer_type_and_insert(v, new_k, value, infer_type);
+            }
         } else if let Some(value) = flat_value.as_object_mut() {
             infer_type_and_insert(v, new_k, value, infer_type)?;
         }
@@ -85,7 +94,7 @@ fn flatten_array(flat_value: &mut Value, new_k: &str, v_array: &[Value], infer_t
         let array_key = format!("{}.{}", new_k, i);
         // if element is object or array recurse
         if obj.is_object() | obj.is_array() {
-            flatten(obj, flat_value, Some(array_key), infer_type)?;
+            flatten(obj, flat_value, Some(array_key), infer_type, false)?;
             // else insert value in the flat_value we're building
         } else if let Some(value) = flat_value.as_object_mut() {
             infer_type_and_insert(obj, array_key, value, infer_type)?;
@@ -103,7 +112,7 @@ mod tests {
         let obj = json!({"key": "value"});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(obj, json!(flat));
     }
 
@@ -112,7 +121,7 @@ mod tests {
         let obj = json!({"key": 1});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key": 1}), json!(flat));
     }
 
@@ -121,7 +130,7 @@ mod tests {
         let obj = json!({"key": "1"});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key": 1}), json!(flat));
     }
 
@@ -130,7 +139,7 @@ mod tests {
         let obj = json!({"key": "1"});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, false).unwrap();
+        flatten(&obj, &mut flat, None, false, false).unwrap();
         assert_eq!(json!({"key": "1"}), json!(flat));
     }
 
@@ -139,7 +148,7 @@ mod tests {
         let obj = json!({"key": "1.0"});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key": 1.}), json!(flat));
     }
 
@@ -148,7 +157,7 @@ mod tests {
         let obj = json!({"key": "true"});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key": true}), json!(flat));
     }
 
@@ -157,7 +166,7 @@ mod tests {
         let obj = json!({"key1": "value1", "key2": "value2"});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(obj, json!(flat));
     }
 
@@ -166,17 +175,26 @@ mod tests {
         let obj = json!({"key": "value", "nested_key": {"key":"value"}});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key": "value", "nested_key.key": "value"}), json!(flat));
     }
 
+
+    #[test]
+    fn nested_single_key_value_skip_arrays() {
+        let obj = json!({"key": "value", "nested_key": {"key":"value"}});
+
+        let mut flat = json!({});
+        flatten(&obj, &mut flat, None, true, true).unwrap();
+        assert_eq!(json!({"key": "value", "nested_key.key": "value"}), json!(flat));
+    }
 
     #[test]
     fn nested_multiple_key_value() {
         let obj = json!({"key": "value", "nested_key": {"key1":"value1", "key2": "value2"}});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key": "value", "nested_key.key1": "value1", "nested_key.key2": "value2"}), json!(flat));
     }
 
@@ -185,7 +203,7 @@ mod tests {
         let obj = json!(["value1", "value2"]);
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({".0": "value1", ".1": "value2"}), json!(flat));
     }
 
@@ -194,7 +212,7 @@ mod tests {
         let obj = json!({"key": ["value1", "value2"]});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key.0": "value1", "key.1": "value2"}), json!(flat));
     }
 
@@ -203,7 +221,7 @@ mod tests {
         let obj = json!({"key": ["value1", {"key": "value2"}]});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"key.0": "value1", "key.1.key": "value2"}), json!(flat));
     }
 
@@ -212,7 +230,24 @@ mod tests {
         let obj = json!({"simple_key": "simple_value", "key": ["value1", {"key": "value2"}, {"nested_array": ["nested1", "nested2", ["nested3", "nested4"]]}]});
 
         let mut flat = json!({});
-        flatten(&obj, &mut flat, None, true).unwrap();
+        flatten(&obj, &mut flat, None, true, false).unwrap();
         assert_eq!(json!({"simple_key": "simple_value", "key.0": "value1", "key.1.key": "value2", "key.2.nested_array.0": "nested1", "key.2.nested_array.1": "nested2", "key.2.nested_array.2.0": "nested3", "key.2.nested_array.2.1": "nested4"}), json!(flat));
+    }
+    #[test]
+    fn nested_array_skip_arrays() {
+        let obj = json!({"key": ["value1", "value2"]});
+
+        let mut flat = json!({});
+        flatten(&obj, &mut flat, None, true, true).unwrap();
+        assert_eq!(json!({"key": ["value1", "value2"]}), json!(flat));
+    }
+
+    #[test]
+    fn nested_obj_array_skip_arrays() {
+        let obj = json!({"key": ["value1", {"key": "value2"}]});
+
+        let mut flat = json!({});
+        flatten(&obj, &mut flat, None, true, true).unwrap();
+        assert_eq!(json!({"key": ["value1", {"key": "value2"}]}), json!(flat));
     }
 }


### PR DESCRIPTION
Added an option to skip flattening of arrays. There are a few potential issues here:

1. The code as written cannot handle a top-level array, it just errors. IMO, It should return the top level array unchanged
2. With so many parameters on all these functions, the API is getting a bit cluttered. Perhaps there is a better way to structure this code (maybe using a configuration object or the builder pattern) for a cleaner API?

Let me know what you think. Thank you!

The ultimate goal here is to mimic the "unwind" function of [json2csv](https://github.com/zemirco/json2csv) in conjunction with this flatten function so that you have multiple options for flattening a json -- either turning arrays into headers with indexes, or splitting out an array into multiple rows.